### PR TITLE
Python Notebook Documentation

### DIFF
--- a/notebooks/main.ipynb
+++ b/notebooks/main.ipynb
@@ -101,7 +101,7 @@
             "Use `test_ratio` to set the percentage of data used to evaluate the model's performance.\n",
             "\n",
             "All remaining data will be used for training."
-               ]
+         ]
       },
       {
          "cell_type": "code",
@@ -853,9 +853,9 @@
          "source": [
             "## 5. Plot a Model's Performance\n",
             "\n",
-            "This cell uses the currently trained model (from section 4) to chart the accuracy of the model as a function of the number of techniques returned by the model.\n",
+            "This cell uses the currently trained model (from section 4) to chart the accuracy of the model over the number of techniques returned by the model.\n",
             "\n",
-            "Ideally, this chart should depict a rapid increase in accuracy as more technique recommendations are included, until the model plateaus at peak accuracy. This indicates that the model is effectively prioritizing the missing techniques at the top of the list."
+            "Ideally, this chart should depict a rapid increase in accuracy as more technique are included before plateauing."
          ]
       },
       {


### PR DESCRIPTION
## What Changed
Adds Markdown documentation to Python Notebook

<img width="906" alt="image" src="https://github.com/user-attachments/assets/a807032d-6441-43d0-849b-f632831696bd">

## Known Limitations
None